### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/kranthi-reddy-gavireddy/products-api/security/code-scanning/1](https://github.com/kranthi-reddy-gavireddy/products-api/security/code-scanning/1)

In general, the fix is to explicitly specify the `permissions` for the `GITHUB_TOKEN` so that the workflow does not inherit potentially broad repository defaults. For a simple build-and-test workflow that only checks out code and runs Go commands, `contents: read` is sufficient.

The best minimal change here is to add a `permissions` block to the `build` job, directly under `runs-on: ubuntu-latest`. This keeps the scope of the change limited to this job and does not alter any existing behavior, because the steps (`checkout`, `setup-go`, `go build`, `go test`) all work with read-only repository contents. No additional imports or methods are needed; this is purely a YAML configuration adjustment in `.github/workflows/go.yml` near line 15.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
