### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,6 +11,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kranthi-reddy-gavireddy/products-api/security/code-scanning/2](https://github.com/kranthi-reddy-gavireddy/products-api/security/code-scanning/2)

To fix the problem, add an explicit `permissions` block to restrict the `GITHUB_TOKEN` to the minimum required scope. In this workflow, the `build` job only checks out the code and builds a Docker image locally, so it only needs read access to repository contents. The best fix is to add `permissions: contents: read` for the `build` job.

Concretely, in `.github/workflows/docker-image.yml`, under `jobs:`, within the `build:` job and at the same indentation level as `runs-on:`, insert:

```yml
    permissions:
      contents: read
```

This keeps existing functionality unchanged while ensuring the `GITHUB_TOKEN` cannot write to the repository from this job. No new imports, methods, or external dependencies are needed, as this is purely a configuration change within the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
