### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   behavior-tests:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/kranthi-reddy-gavireddy/products-api/security/code-scanning/6](https://github.com/kranthi-reddy-gavireddy/products-api/security/code-scanning/6)

In general, the fix is to explicitly set GITHUB_TOKEN permissions in the workflow to the minimal required set. Since this workflow only checks out the code and runs tests, it only needs read access to repository contents.

The best targeted fix is to add a `permissions` block to the `behavior-tests` job in `.github/workflows/testing.yml`, directly under `runs-on: ubuntu-latest`, with `contents: read`. This limits the job’s token to read-only repository contents and doesn’t change existing behavior, because no write operations are performed in the steps.

Concretely:
- Edit `.github/workflows/testing.yml`.
- In the `jobs.behavior-tests` section, add:
  ```yaml
  permissions:
    contents: read
  ```
- Keep all existing steps intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
